### PR TITLE
[Fix] Deleting entry with size matching delete size fails

### DIFF
--- a/src/piece_table.zig
+++ b/src/piece_table.zig
@@ -234,7 +234,7 @@ pub fn delete(self: *@This(), index: Pos, length: Pos) error{ OutOfBounds, OutOf
         if (entries_to_delete > 0) {
             const i = entry_index;
             const n = entries_to_delete;
-            try self.entries.replaceRange(i, n, &[0]Entry{});
+            self.entries.replaceRangeAssumeCapacity(i, n, &[0]Entry{});
         }
 
         if (length_to_delete != 0) {


### PR DESCRIPTION
Got another PR for you, only just realised this when debugging some issues in my text editor. Works perfectly otherwise though.

When the number of entries to delete is computed, the condition for exiting the loop is that the length mismatches the currently considered entry (i.e. it's smaller than it).

However, in the case that we delete an entry with a length matching the size of the requested delete, the loop will continue without breaking, causing the count of entries to delete to be incorrectly computed.